### PR TITLE
Fix security group rules for inbound traffic

### DIFF
--- a/aws/security-groups/createBrokerSG.ts
+++ b/aws/security-groups/createBrokerSG.ts
@@ -59,16 +59,11 @@ const authorizeIngressTraffic = async (
 ): Promise<void> => {
   try {
     const ingressRules = [
-      { IpProtocol: "tcp", FromPort: 5672, ToPort: 5672, CidrIp: "0.0.0.0/0" }, // RabbitMQ
-      {
-        IpProtocol: "tcp",
-        FromPort: 15672,
-        ToPort: 15672,
-        CidrIp: "0.0.0.0/0",
-      }, // RabbitMQ management UI
-      { IpProtocol: "tcp", FromPort: 80, ToPort: 80, CidrIp: "0.0.0.0/0" }, // HTTP
-      { IpProtocol: "tcp", FromPort: 443, ToPort: 443, CidrIp: "0.0.0.0/0" }, // HTTPS
-      { IpProtocol: "tcp", FromPort: 22, ToPort: 22, CidrIp: "0.0.0.0/0" }, // SSH
+      { IpProtocol: "tcp", FromPort: 5672, ToPort: 5672, IpRanges: [{ CidrIp: "0.0.0.0/0" }] }, // RabbitMQ
+      { IpProtocol: "tcp", FromPort: 15672, ToPort: 15672, IpRanges: [{ CidrIp: "0.0.0.0/0" }] }, // RabbitMQ management UI
+      { IpProtocol: "tcp", FromPort: 80, ToPort: 80, IpRanges: [{ CidrIp: "0.0.0.0/0" }] }, // HTTP
+      { IpProtocol: "tcp", FromPort: 443, ToPort: 443, IpRanges: [{ CidrIp: "0.0.0.0/0" }] }, // HTTPS
+      { IpProtocol: "tcp", FromPort: 22, ToPort: 22, IpRanges: [{ CidrIp: "0.0.0.0/0" }] }, // SSH
     ];
 
     const authorizeIngressCommand = new AuthorizeSecurityGroupIngressCommand({
@@ -89,7 +84,6 @@ export const setupBrokerSG = async (): Promise<string> => {
     const vpcId = await getVpcId();
     const securityGroupId = await createBrokerSecurityGroup(vpcId);
     await authorizeIngressTraffic(securityGroupId);
-    // await authorizeEgressTraffic(securityGroupId);
 
     console.log(
       "Security group setup completed successfully for BrokerSecurityGroup.",

--- a/aws/security-groups/createRabbitoryEngineSG.ts
+++ b/aws/security-groups/createRabbitoryEngineSG.ts
@@ -59,10 +59,10 @@ const createRabbitoryEngineSG = async (vpcId: string): Promise<string> => {
 const authorizeIngressTraffic = async (securityGroupId: string): Promise<void> => {
   try {
     const ingressRules = [
-      { IpProtocol: "tcp", FromPort: 22, ToPort: 22, CidrIp: "0.0.0.0/0" }, // SSH
-      { IpProtocol: "tcp", FromPort: 80, ToPort: 80, CidrIp: "0.0.0.0/0" }, // HTTP
-      { IpProtocol: "tcp", FromPort: 443, ToPort: 443, CidrIp: "0.0.0.0/0" }, // HTTPS
-      { IpProtocol: "tcp", FromPort: 3000, ToPort: 3000, CidrIp: "0.0.0.0/0" }, // Next.js app on port 3000
+      { IpProtocol: "tcp", FromPort: 22, ToPort: 22, IpRanges: [{ CidrIp: "0.0.0.0/0" }] }, // SSH
+      { IpProtocol: "tcp", FromPort: 80, ToPort: 80, IpRanges: [{ CidrIp: "0.0.0.0/0" }] }, // HTTP
+      { IpProtocol: "tcp", FromPort: 443, ToPort: 443, IpRanges: [{ CidrIp: "0.0.0.0/0" }] }, // HTTPS
+      { IpProtocol: "tcp", FromPort: 3000, ToPort: 3000, IpRanges: [{ CidrIp: "0.0.0.0/0" }] }, // Next.js app on port 3000
     ];
 
     const authorizeIngressCommand = new AuthorizeSecurityGroupIngressCommand({
@@ -81,9 +81,9 @@ const authorizeIngressTraffic = async (securityGroupId: string): Promise<void> =
 const authorizeEgressTraffic = async (securityGroupId: string): Promise<void> => {
   try {
     const egressRules = [
-      { IpProtocol: "tcp", FromPort: 80, ToPort: 80, CidrIp: "0.0.0.0/0" },  // HTTP
-      { IpProtocol: "tcp", FromPort: 443, ToPort: 443, CidrIp: "0.0.0.0/0" }, // HTTPS
-      { IpProtocol: "tcp", FromPort: 3000, ToPort: 3000, CidrIp: "0.0.0.0/0" }, // Next.js app on port 3000
+      { IpProtocol: "tcp", FromPort: 80, ToPort: 80, IpRanges: [{ CidrIp: "0.0.0.0/0" }] },  // HTTP
+      { IpProtocol: "tcp", FromPort: 443, ToPort: 443, IpRanges: [{ CidrIp: "0.0.0.0/0" }] }, // HTTPS
+      { IpProtocol: "tcp", FromPort: 3000, ToPort: 3000, IpRanges: [{ CidrIp: "0.0.0.0/0" }] }, // Next.js app on port 3000
     ];
 
     const authorizeEgressCommand = new AuthorizeSecurityGroupEgressCommand({

--- a/aws/security-groups/createRabbitoryEngineSG.ts
+++ b/aws/security-groups/createRabbitoryEngineSG.ts
@@ -91,5 +91,3 @@ export const setupRabbitorySG = async (): Promise<string> => {
     throw err;
   }
 };
-
-// Working on fix

--- a/aws/security-groups/createRabbitoryEngineSG.ts
+++ b/aws/security-groups/createRabbitoryEngineSG.ts
@@ -113,3 +113,5 @@ export const setupRabbitorySG = async (): Promise<string> => {
     throw err;
   }
 };
+
+// Working on fix

--- a/aws/security-groups/createRabbitoryEngineSG.ts
+++ b/aws/security-groups/createRabbitoryEngineSG.ts
@@ -78,33 +78,11 @@ const authorizeIngressTraffic = async (securityGroupId: string): Promise<void> =
   }
 };
 
-const authorizeEgressTraffic = async (securityGroupId: string): Promise<void> => {
-  try {
-    const egressRules = [
-      { IpProtocol: "tcp", FromPort: 80, ToPort: 80, IpRanges: [{ CidrIp: "0.0.0.0/0" }] },  // HTTP
-      { IpProtocol: "tcp", FromPort: 443, ToPort: 443, IpRanges: [{ CidrIp: "0.0.0.0/0" }] }, // HTTPS
-      { IpProtocol: "tcp", FromPort: 3000, ToPort: 3000, IpRanges: [{ CidrIp: "0.0.0.0/0" }] }, // Next.js app on port 3000
-    ];
-
-    const authorizeEgressCommand = new AuthorizeSecurityGroupEgressCommand({
-      GroupId: securityGroupId,
-      IpPermissions: egressRules,
-    });
-
-    await ec2Client.send(authorizeEgressCommand);
-    console.log("Egress rules set up successfully for RabbitoryEngineSG");
-  } catch (error) {
-    console.error("Error authorizing egress rules:", error);
-    throw error;
-  }
-};
-
 export const setupRabbitorySG = async (): Promise<string> => {
   try {
     const vpcId = await getVpcId();
     const securityGroupId = await createRabbitoryEngineSG(vpcId);
     await authorizeIngressTraffic(securityGroupId);
-    await authorizeEgressTraffic(securityGroupId);
     
     console.log("Security group setup completed successfully for RabbitoryEngineSG.");
     return securityGroupId;


### PR DESCRIPTION
Just needed to adjust the structure of the objects in the inboundRules array. Also went ahead and deleted egress rules for RabbitoryEngineSG, as typically you allow all outbound traffic but limit inbound traffic.